### PR TITLE
Optimize Epic extension flatpak remote configuration

### DIFF
--- a/defaults/scripts/Extensions/Epic/install_deps.sh
+++ b/defaults/scripts/Extensions/Epic/install_deps.sh
@@ -16,7 +16,9 @@ function uninstall() {
 
 function download_and_install() {
     cd /tmp
-    flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+    if ! flatpak remotes --columns=name | grep -qx "flathub"; then
+        flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+    fi
     flatpak --user install flathub org.gnome.Platform//49 -y
     flatpak --user install com.github.Matoking.protontricks -y
     wget $DOWNLOAD_LOCATION


### PR DESCRIPTION
Prevent adding flathub remote if flathub has configured system-wide, resulting duplicated flathub remotes