### PR TITLE
Fetch system Flathub URL for user-level remote setup in Epic extension setup

### DIFF
--- a/defaults/scripts/Extensions/Epic/install_deps.sh
+++ b/defaults/scripts/Extensions/Epic/install_deps.sh
@@ -16,8 +16,10 @@ function uninstall() {
 
 function download_and_install() {
     cd /tmp
-    if ! flatpak remotes --columns=name | grep -qx "flathub"; then
-        flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+    flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+    SYS_URL=$(flatpak remotes --system --columns=name,url | awk '$1=="flathub"{print $2}')
+    if [ -n "$SYS_URL" ]; then
+        flatpak remote-modify --user flathub --url="$SYS_URL"
     fi
     flatpak --user install flathub org.gnome.Platform//49 -y
     flatpak --user install com.github.Matoking.protontricks -y


### PR DESCRIPTION
Improves the way the Flathub remote is added at the user level. Instead of always using a hardcoded URL, the script now attempts to detect and reuse the URL from the system-level Flathub configuration if it exists. By doing this user configured Flathub mirror can be respected.